### PR TITLE
Initialize Konva.js for canvas functionality

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,17 @@
-# Frontend
+# Frontend Canvas Setup
 
-This directory contains the code for the user interface of the application. This includes all client-side logic, components, and assets.
+This frontend uses HTML, JavaScript, and the Konva.js library to provide a canvas for drawing.
+
+## Setup
+
+The Konva.js library is included via a CDN in `public/index.html`.
+The main JavaScript for initializing and drawing on the canvas is in `frontend/main.js`.
+The main HTML page is `public/index.html`.
+
+## Running the Example
+
+To see the canvas in action with a sample rectangle:
+1. Ensure you have a web browser.
+2. Open the `public/index.html` file directly in your web browser (e.g., by double-clicking it or using "File > Open" in your browser).
+
+You should see a green rectangle drawn on a white background.

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,27 @@
+// Initialize Konva stage
+var stage = new Konva.Stage({
+  container: 'container', // id of container <div>
+  width: 500,
+  height: 500
+});
+
+// Add a layer to the stage
+var layer = new Konva.Layer();
+stage.add(layer);
+
+// Create a simple rectangle
+var rect = new Konva.Rect({
+  x: 50,
+  y: 50,
+  width: 100,
+  height: 50,
+  fill: 'green',
+  stroke: 'black',
+  strokeWidth: 4
+});
+
+// Add the rectangle to the layer
+layer.add(rect);
+
+// Draw the layer
+layer.draw();

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,9 @@
     <title>My Application</title>
 </head>
 <body>
+    <div id="container"></div>
     <h1>Welcome to My Application</h1>
+    <script src="https://unpkg.com/konva@9/konva.min.js"></script>
+    <script src="../frontend/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit sets up a basic HTML page (`public/index.html`) and integrates the Konva.js library via CDN.

A new JavaScript file (`frontend/main.js`) is created to:
- Initialize a Konva Stage and Layer.
- Draw a sample green rectangle to demonstrate functionality.

The `frontend/README.md` has been updated to explain the setup and how you can run the example by opening `public/index.html` in a browser.