### PR TITLE
feat: Implement draggable sidebar component and drop functionality

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,16 +1,16 @@
-// Initialize Konva stage
-var stage = new Konva.Stage({
+// Initialize Konva stage for main content
+var mainStage = new Konva.Stage({
   container: 'container', // id of container <div>
-  width: 500,
-  height: 500
+  width: 500, // Should match the container div's width or be dynamic
+  height: 500 // Should match the container div's height or be dynamic
 });
 
-// Add a layer to the stage
-var layer = new Konva.Layer();
-stage.add(layer);
+// Add a layer to the main stage
+var mainLayer = new Konva.Layer();
+mainStage.add(mainLayer);
 
-// Create a simple rectangle
-var rect = new Konva.Rect({
+// Create a simple rectangle in the main stage
+var mainRect = new Konva.Rect({
   x: 50,
   y: 50,
   width: 100,
@@ -20,8 +20,101 @@ var rect = new Konva.Rect({
   strokeWidth: 4
 });
 
-// Add the rectangle to the layer
-layer.add(rect);
+// Add the rectangle to the main layer
+mainLayer.add(mainRect);
 
-// Draw the layer
-layer.draw();
+// Draw the main layer
+mainLayer.draw();
+
+// Get the sidebar element
+const sidebarDiv = document.getElementById('sidebar');
+
+// Initialize Konva stage for sidebar
+if (sidebarDiv) {
+  var sidebarStage = new Konva.Stage({
+    container: sidebarDiv, // Use the div element directly
+    width: sidebarDiv.clientWidth, // Dynamically set width
+    height: 200 // Example height, adjust as needed
+  });
+
+  // Add a layer to the sidebar stage
+  var sidebarLayer = new Konva.Layer();
+  sidebarStage.add(sidebarLayer);
+
+  // Create a 'Dummy Component' rectangle for the sidebar
+  const initialSidebarComponentX = 10;
+  const initialSidebarComponentY = 10;
+  var dummyComponent = new Konva.Rect({
+    x: initialSidebarComponentX,
+    y: initialSidebarComponentY,
+    width: 50,
+    height: 50,
+    fill: 'blue',
+    stroke: 'black',
+    strokeWidth: 2,
+    draggable: true // Make the component draggable
+  });
+
+  // Add the dummy component to the sidebar layer
+  sidebarLayer.add(dummyComponent);
+
+  // Draw the sidebar layer
+  sidebarLayer.draw();
+
+  // Event listener for when the draggable sidebar component is dropped
+  dummyComponent.on('dragend', function() {
+    console.log("Sidebar dummy component drag ended.");
+
+    // Get the pointer position relative to the main stage.
+    // This is where the user dropped the component.
+    var pointerPosition = mainStage.getPointerPosition();
+
+    // Reset the original sidebar component to its initial position
+    dummyComponent.position({ x: initialSidebarComponentX, y: initialSidebarComponentY });
+    sidebarLayer.draw(); // Redraw sidebar layer to show the component back in place
+    console.log("Sidebar dummy component position reset.");
+
+    // If pointerPosition is null, it means the drop happened outside any Konva stage,
+    // or the mainStage is not present.
+    if (!pointerPosition) {
+        console.warn("Drop event occurred, but pointer position is not available (possibly dropped outside of any Konva area or mainStage missing).");
+        return;
+    }
+
+    // Check if the drop position is within the valid bounds of the mainStage.
+    // We subtract the component's dimensions from the stage dimensions for the x, y checks
+    // to ensure the entire component is within the bounds, assuming x,y is top-left.
+    // For this example, we'll check if the drop point (cursor) is within the stage.
+    // A more robust check might ensure the entire new shape fits.
+    const withinXBounds = pointerPosition.x > 0 && pointerPosition.x < mainStage.width();
+    const withinYBounds = pointerPosition.y > 0 && pointerPosition.y < mainStage.height();
+
+    if (withinXBounds && withinYBounds) {
+      console.log(`Drop position (main stage relative): X=${pointerPosition.x}, Y=${pointerPosition.y} - Within bounds.`);
+
+      // Create a new rectangle (a "clone" of the dummy component) on the main stage
+      var newRect = new Konva.Rect({
+        // Adjust x and y to center the new rectangle on the pointer position
+        x: pointerPosition.x - dummyComponent.width() / 2,
+        y: pointerPosition.y - dummyComponent.height() / 2,
+        width: dummyComponent.width(),
+        height: dummyComponent.height(),
+        fill: 'red', // Different color to distinguish from the sidebar component
+        stroke: 'black',
+        strokeWidth: 2,
+        draggable: true // Make this new component on the main stage draggable as well
+      });
+
+      // Add the new rectangle to the main layer
+      mainLayer.add(newRect);
+      // Redraw the main layer to display the new component
+      mainLayer.draw();
+      console.log("New component created on main stage and main layer redrawn.");
+    } else {
+      console.log(`Drop position (main stage relative): X=${pointerPosition.x}, Y=${pointerPosition.y} - Outside main stage bounds.`);
+    }
+  });
+
+} else {
+  console.error("Sidebar element not found! Cannot initialize sidebar stage or dummy component.");
+}

--- a/public/index.html
+++ b/public/index.html
@@ -5,9 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Application</title>
 </head>
-<body>
-    <div id="container"></div>
-    <h1>Welcome to My Application</h1>
+<body style="display: flex; margin: 0; height: 100vh;">
+
+    <div id="sidebar" style="width: 200px; background-color: #f0f0f0; padding: 20px;">
+        <h2>Sidebar</h2>
+        <!-- Add sidebar content here -->
+    </div>
+
+    <div id="main-content" style="flex-grow: 1; padding: 20px; display: flex; flex-direction: column;">
+        <h1>Welcome to My Application</h1>
+        <div id="container" style="width: 100%; height: 500px; background-color: #ddd;"></div>
+    </div>
+
     <script src="https://unpkg.com/konva@9/konva.min.js"></script>
     <script src="../frontend/main.js"></script>
 </body>


### PR DESCRIPTION
This commit introduces a sidebar with a draggable 'Dummy Component' (a Konva.Rect) that can be dragged onto a main Konva stage.

Key changes:
- Modified `public/index.html`:
    - Added a sidebar div (`#sidebar`) and a main content area div (`#main-content`).
    - Styled these elements for a basic two-column layout.
    - The existing Konva container (`#container`) is now within `#main-content`.
- Updated `frontend/main.js`:
    - Initialized a new Konva stage (`sidebarStage`) within the `#sidebar` div.
    - Created a blue 'Dummy Component' (`dummyComponent`) Konva.Rect on this `sidebarStage`.
    - Implemented drag-and-drop functionality:
        - The `dummyComponent` is draggable.
        - On `dragend`, if the component is dropped within the bounds of the main Konva stage (`mainStage`), a new red Konva.Rect is created at the drop position on the `mainStage`. - The new components on the `mainStage` are also draggable. - The original `dummyComponent` in the sidebar resets to its initial position after being dragged, allowing for multiple components to be created.
    - Added comments and console logs for clarity and easier debugging.