### PR TITLE
feat: Implement basic Component Registry & Loader

### DIFF
--- a/backend/component_registry.py
+++ b/backend/component_registry.py
@@ -1,0 +1,68 @@
+import os
+import json
+from pathlib import Path
+from typing import Dict # Import Dict for type hinting
+
+from shared_types.component_manifest import ComponentManifest
+
+class ComponentRegistry:
+    def __init__(self) -> None:
+        self.manifests: Dict[str, ComponentManifest] = {}
+
+    def discover_components(self, components_dir_path: str | Path) -> None:
+        if not isinstance(components_dir_path, Path):
+            components_dir_path = Path(components_dir_path)
+
+        if not components_dir_path.is_dir():
+            print(f"Error: Components directory not found at {components_dir_path}")
+            return
+
+        for item in components_dir_path.iterdir():
+            if item.is_dir():
+                manifest_path = item / "manifest.json"
+                if manifest_path.exists() and manifest_path.is_file():
+                    try:
+                        with open(manifest_path, 'r') as f:
+                            manifest_data = json.load(f)
+
+                        # Validate required keys by attempting to create ComponentManifest
+                        try:
+                            component_name = manifest_data['name']
+                            component_version = manifest_data['version']
+                            component_description = manifest_data['description']
+
+                            manifest = ComponentManifest(
+                                name=component_name,
+                                version=component_version,
+                                description=component_description
+                            )
+                            self.manifests[component_name] = manifest
+                            # print(f"Successfully loaded manifest for component: {component_name}")
+                        except KeyError as e:
+                            print(f"Error: Missing key {e} in manifest {manifest_path}")
+                        except Exception as e: # Catch other errors during TypedDict creation
+                            print(f"Error: Could not create ComponentManifest for {manifest_path}: {e}")
+
+                    except json.JSONDecodeError:
+                        print(f"Error: Malformed JSON in manifest file: {manifest_path}")
+                    except FileNotFoundError:
+                        # This case should ideally not be reached due to the prior check,
+                        # but included for robustness.
+                        print(f"Error: Manifest file not found: {manifest_path}")
+                    except Exception as e:
+                        print(f"An unexpected error occurred while processing {manifest_path}: {e}")
+                # else:
+                    # print(f"Info: No manifest.json found in component directory: {item}")
+        # print(f"Discovery complete. Found {len(self.manifests)} components.")
+
+    def get_component_manifest(self, component_name: str) -> ComponentManifest | None:
+        """
+        Retrieves the manifest for a given component name.
+
+        Args:
+            component_name: The name of the component.
+
+        Returns:
+            The ComponentManifest if found, otherwise None.
+        """
+        return self.manifests.get(component_name)

--- a/backend/tests/test_component_registry.py
+++ b/backend/tests/test_component_registry.py
@@ -1,0 +1,75 @@
+import unittest
+import sys
+import os
+from pathlib import Path
+
+# Add repository root to sys.path to allow direct imports of modules
+# Assuming the script is run from the repository root or the tests directory
+# Adjust if the execution context is different.
+# For `python -m unittest backend.tests.test_component_registry` from root,
+# Python automatically handles the paths for `backend.` and `shared_types.`
+# However, to be robust for other execution methods, we can add this.
+# current_dir = Path(__file__).parent
+# repo_root = current_dir.parent.parent # Assuming tests is in backend/tests
+# sys.path.insert(0, str(repo_root))
+
+
+from backend.component_registry import ComponentRegistry
+from shared_types.component_manifest import ComponentManifest
+
+# Define the path to the components directory relative to this test file
+# Or, more robustly, relative to the assumed repository root.
+# If tests are run from repo root:
+COMPONENTS_DIR = Path("components")
+
+class TestComponentRegistry(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        self.registry = ComponentRegistry()
+        # Ensure the components directory path is correct.
+        # If this test file is backend/tests/test_component_registry.py,
+        # and components is at the root, then components_dir should be resolved correctly.
+        self.registry.discover_components(COMPONENTS_DIR)
+
+    def test_discover_dummy_component(self):
+        """Test that the dummy component is discovered."""
+        self.assertTrue(self.registry.manifests, "Manifests dictionary should not be empty.")
+        self.assertIn("Dummy Component", self.registry.manifests, "Dummy Component should be in manifests.")
+
+        manifest = self.registry.manifests["Dummy Component"]
+        self.assertIsNotNone(manifest, "Manifest for Dummy Component should not be None.")
+
+        # Type checking for manifest will assume it's ComponentManifest
+        # but it's good to be explicit in tests.
+        self.assertEqual(manifest['name'], "Dummy Component")
+        self.assertEqual(manifest['version'], "1.0.0")
+        self.assertEqual(manifest['description'], "A dummy component for demonstration purposes.")
+
+    def test_get_component_manifest(self):
+        """Test retrieving an existing component's manifest."""
+        manifest = self.registry.get_component_manifest("Dummy Component")
+        self.assertIsNotNone(manifest, "Should retrieve manifest for Dummy Component.")
+        if manifest: # Check to satisfy type checkers and for safety
+            self.assertEqual(manifest['name'], "Dummy Component")
+
+    def test_get_missing_component_manifest(self):
+        """Test retrieving a non-existent component's manifest."""
+        manifest = self.registry.get_component_manifest("NonExistentComponent")
+        self.assertIsNone(manifest, "Should return None for a non-existent component.")
+
+if __name__ == '__main__':
+    # This allows running the tests directly from this file, e.g., python backend/tests/test_component_registry.py
+    # For this to work, Python needs to be able to find 'backend' and 'shared_types'.
+    # If run from repo root as `python -m unittest backend.tests.test_component_registry`, this __main__ block is not executed.
+
+    # A common pattern for making sure modules are found when running a test file directly:
+    # Get the absolute path to the project root.
+    project_root = Path(__file__).resolve().parent.parent.parent # backend/tests/test_... -> backend/ -> root
+    sys.path.insert(0, str(project_root))
+
+    # Now re-import with the updated path if necessary, or rely on initial imports if they work.
+    # This is tricky because imports happen at the top.
+    # The best practice is to run tests using `python -m unittest discover` or similar from the root.
+
+    unittest.main()

--- a/shared_types/component_manifest.py
+++ b/shared_types/component_manifest.py
@@ -1,0 +1,6 @@
+from typing import TypedDict
+
+class ComponentManifest(TypedDict):
+    name: str
+    version: str
+    description: str


### PR DESCRIPTION
This commit introduces a basic component registry and loader system.

Key features:
- A `ComponentManifest` TypedDict in `shared_types` to define the structure of component manifest files.
- A `ComponentRegistry` class in `backend.component_registry` capable of:
    - Discovering components by scanning a directory for `manifest.json` files.
    - Parsing these JSON manifests into `ComponentManifest` objects.
    - Storing and providing access to these manifests.
- A `get_component_manifest` method in `ComponentRegistry` to retrieve individual component manifests by name.
- Unit tests for the `ComponentRegistry` to ensure correct discovery, parsing, and retrieval of component data, specifically testing with the existing `DummyComponent`.

The system is designed to locate `manifest.json` files within subdirectories of a given components directory (e.g., `components/`). It parses these files and makes the component information available.