### PR TITLE
feat: Implement create and update lifecycle methods for AIChatInterface

### DIFF
--- a/components/AIChatInterface/backend.py
+++ b/components/AIChatInterface/backend.py
@@ -3,7 +3,39 @@ import time # To simulate streaming
 class AIChatInterfaceBackend:
     def __init__(self):
         # In a real scenario, this might load a model or set up connections.
-        pass
+        self.config = {}
+
+    def create(self, config: dict):
+        """
+        Stores the configuration for the AIChatInterface.
+        """
+        self.config = config
+        # In a real backend, you might use this config to initialize things
+        print(f"AIChatInterfaceBackend created with config: {self.config}")
+        return {"status": "success", "message": "Configuration received."}
+
+    def update(self, inputs: dict):
+        """
+        Processes user input and returns a response.
+        """
+        if 'userInput' in inputs:
+            user_input = inputs['userInput']
+            # Get temperature and max_tokens from inputs, with defaults from process_request's signature
+            # However, since process_request has defaults, we can just pass them if they exist,
+            # or let process_request handle the defaults if they don't.
+            temperature = inputs.get('temperature', 0.7)
+            max_tokens = inputs.get('max_tokens', 256)
+
+            # Potentially use self.config here if needed for process_request
+            # For example: self.process_request(user_input, self.config.get('temperature', 0.7), ...)
+            # But for now, let's stick to the prompt's direct instructions.
+            return self.process_request(user_input, temperature, max_tokens)
+        else:
+            return {
+                "responseText": "No input provided.",
+                "responseStream": "",
+                "error": False
+            }
 
     def process_request(self, user_input: str, temperature: float = 0.7, max_tokens: int = 256):
         """


### PR DESCRIPTION
I've added `create(config)` and `update(inputs)` lifecycle methods to the `AIChatInterfaceBackend` class as per the design document.

- The `create(config)` method initializes the component's state by storing the provided configuration.
- The `update(inputs)` method handles new input values. If 'userInput' is present, it triggers the `process_request` method, passing relevant parameters. Otherwise, it returns a default response.

I've also added unit tests for both methods to ensure they function correctly:
- `test_create_stores_config` verifies that configuration is stored.
- `test_update_with_user_input` and `test_update_with_user_input_default_params` check the handling of 'userInput' and parameter passing to `process_request`.
- `test_update_without_user_input` verifies the default response when 'userInput' is absent.
- `test_update_passes_all_params_to_process_request` uses mocking to confirm `process_request` is called appropriately.

The `manifest.json` was reviewed, and no changes were required as lifecycle methods are implicitly handled by the backend module.