### PR TITLE
Fix: Display backend errors in chat component

### DIFF
--- a/frontend/AIChatInterface.js
+++ b/frontend/AIChatInterface.js
@@ -33,10 +33,12 @@ const AIChatInterface = () => {
 
       const data = await response.json();
       console.log('Success:', data);
-      if (data.responseText) {
+      if (data.error) {
+        setError(data.error);
+      } else if (data.responseText) {
         setResponseText(data.responseText);
       } else {
-        setError('No responseText found in the response.');
+        setError('No actionable content in response.');
       }
     } catch (error) {
       console.error('Error:', error);


### PR DESCRIPTION
The chat interface frontend was updated to correctly process and display error messages sent by the backend.

Previously, the frontend primarily handled fetch-related errors or missing 'responseText'. This change ensures that if the backend response includes an 'error' field (as facilitated by the `emit('error', ...)` utility), this error message is now shown to you.

The `frontend/AIChatInterface.js` component's `handleSubmit` function was modified to:
- Check for `data.error` in the parsed JSON response.
- If `data.error` is present, set it as the error state for display.
- Otherwise, proceed to handle `data.responseText` or other conditions.