### PR TITLE
feat: Enhance wire dragging visual feedback

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -190,12 +190,18 @@ if (sidebarDiv) {
         mainStage.container().style.cursor = 'pointer';
         this.fill('yellow');
         this.radius(portRadius * 1.2);
+        if (isWiring && currentWire) {
+          currentWire.stroke('green');
+        }
         mainLayer.draw();
       });
       inputPort.on('mouseleave', function() {
         mainStage.container().style.cursor = 'default';
         this.fill(portFill);
         this.radius(portRadius);
+        if (isWiring && currentWire) {
+          currentWire.stroke('dodgerblue');
+        }
         mainLayer.draw();
       });
 


### PR DESCRIPTION
This commit implements visual feedback for the wire dragging operation in the frontend.

When you drag a wire from an output port:
- If the wire hovers over a valid input port, its color changes to green, indicating a possible connection.
- If the wire is moved away from a valid input port while still dragging, its color reverts to the default 'dodgerblue'.

This enhancement provides you with clearer visual cues during the circuit design process. The changes were made in `frontend/main.js` by updating the `mouseenter` and `mouseleave` event handlers for input ports to modify the `currentWire`'s stroke color based on its proximity to valid targets.