### PR TITLE
fix: Resolve component loading and instantiation errors at startup

### DIFF
--- a/components/AIChatInterface/manifest.json
+++ b/components/AIChatInterface/manifest.json
@@ -13,5 +13,6 @@
       {"name": "responseStream", "type": "stream"},
       {"name": "error", "type": "boolean"}
     ]
-  }
+  },
+  "backend_class": "AIChatInterfaceBackend"
 }

--- a/components/DummyComponent/backend.py
+++ b/components/DummyComponent/backend.py
@@ -1,0 +1,36 @@
+# This is a placeholder backend for DummyComponent.
+# It allows the component discovery mechanism to import a module,
+# preventing a ModuleNotFoundError.
+# This component might be frontend-only, or its backend is not yet implemented.
+
+# To truly make it frontend-only, the component registry would ideally
+# check for the presence of 'backend_class' in manifest.json before
+# attempting to import a backend module.
+
+# Placeholder class (optional, but might prevent AttributeError if registry tries to getattr)
+class DummycomponentBackend:
+    def __init__(self, *args, **kwargs):
+        print("DummycomponentBackend initialized (placeholder)")
+
+    def update(self, inputs):
+        print(f"DummycomponentBackend update called with: {inputs}")
+        return {}
+
+    def get_state(self):
+        print("DummycomponentBackend get_state called")
+        return {}
+
+logger = None
+try:
+    import logging
+    logger = logging.getLogger(__name__)
+    if logger:
+        logger.info("DummyComponent backend placeholder loaded.")
+except ImportError:
+    pass
+
+if __name__ == '__main__':
+    if logger:
+        logger.info("DummyComponent backend placeholder script executed directly.")
+    else:
+        print("DummyComponent backend placeholder script executed directly (logging not available).")


### PR DESCRIPTION
This commit addresses several issues that prevented the backend server from starting correctly:

1.  Resolved `TypeError` for `AIChatInterfaceBackend` instantiation:
    - I guided you to remove a redundant and incorrect direct instantiation of `AIChatInterfaceBackend` from the `main()` function in `backend/server.py`. The component is correctly instantiated by the `ComponentRegistry`.

2.  Fixed `AttributeError` for `AIChatInterfaceBackend` lookup:
    - I added the missing `backend_class`: `"AIChatInterfaceBackend"` field to `components/AIChatInterface/manifest.json`. This ensures the `ComponentRegistry` uses the correct class name (with proper casing) when loading the component's backend.

3.  Addressed `ModuleNotFoundError` for `DummyComponent.backend`:
    - I created a placeholder backend file `components/DummyComponent/backend.py` with a minimal `DummycomponentBackend` class. This allows the `ComponentRegistry` to successfully import a backend module for `DummyComponent`, which it attempts to do by default.

These changes should allow the server to start up without the previously reported component-related errors.