### PR TITLE
feat: Update backend component graph and connection representation

### DIFF
--- a/shared_types/connection.py
+++ b/shared_types/connection.py
@@ -1,0 +1,11 @@
+from typing import Any, Callable, Coroutine, TypedDict
+
+class Connection(TypedDict):
+    connection_id: str
+    source_component_id: str
+    source_port_name: str
+    target_component_id: str
+    target_port_name: str
+    status: str
+    event_name: str
+    callback: Callable[[Any], Coroutine[Any, Any, None]]


### PR DESCRIPTION
I've refined the backend's representation of component connections and enhanced the component graph's explicit tracking of these connections.

Key changes include:

1.  Introduced a `Connection` TypedDict in `shared_types/connection.py` to provide a structured representation for active connections, replacing plain dictionaries in `backend/server.py`.
2.  Updated `backend/server.py` (`handle_connection_create`, `handle_connection_delete`, and `active_connections` dictionary) to use the new `Connection` type.
3.  Enhanced `backend/component_registry.py` (`ComponentRegistry`) to explicitly track connection IDs associated with each component:
    *   Added `component_connections: Dict[str, List[str]]` to store mappings.
    *   Implemented methods: `add_connection_to_component`, `remove_connection_from_component`, and `get_connections_for_component`.
    *   The `clear()` method now also clears `component_connections`.
4.  Modified `backend/server.py` to call the new `ComponentRegistry` methods when connections are created or deleted, ensuring the registry's connection tracking is synchronized.
5.  Added and updated unit tests in `backend/tests/test_component_registry.py` and `backend/tests/test_server.py` to cover these new functionalities and ensure interactions between `server.py` and `ComponentRegistry` are correctly implemented.